### PR TITLE
Fixed bad parsing Information field of UA response

### DIFF
--- a/development/src/main/java/gurux/dlms/GXDLMSClient.java
+++ b/development/src/main/java/gurux/dlms/GXDLMSClient.java
@@ -529,17 +529,17 @@ public class GXDLMSClient {
             default:
                 throw new GXDLMSException("Invalid Exception.");
             }
-            switch (id) {
-            case HDLCInfo.MAX_INFO_TX:
+            switch (id) { // RX / TX are delivered from the partner's point of view => reversed to ours
+            case HDLCInfo.MAX_INFO_RX:
                 getLimits().setMaxInfoTX(val);
                 break;
-            case HDLCInfo.MAX_INFO_RX:
+            case HDLCInfo.MAX_INFO_TX:
                 getLimits().setMaxInfoRX(val);
                 break;
-            case HDLCInfo.WINDOW_SIZE_TX:
+            case HDLCInfo.WINDOW_SIZE_RX:
                 getLimits().setWindowSizeTX(val);
                 break;
-            case HDLCInfo.WINDOW_SIZE_RX:
+            case HDLCInfo.WINDOW_SIZE_TX:
                 getLimits().setWindowSizeRX(val);
                 break;
             default:


### PR DESCRIPTION
Original parsing of Information field of UA response swapped values of MAX_INFO_TX with MAX_INFO_RX and WINDOW_SIZE_TX with WINDOW_SIZE_RX. Those values are set by sender of the message and from his point of view - they should be interpreted: his RX -> my TX and vice versa.