### PR TITLE
fixed AARE association rejected check

### DIFF
--- a/development/src/main/java/gurux/dlms/GXAPDU.java
+++ b/development/src/main/java/gurux/dlms/GXAPDU.java
@@ -932,11 +932,6 @@ final class GXAPDU {
                 break;
             case BerType.CONTEXT | BerType.CONSTRUCTED
                     | PduType.USER_INFORMATION:// 0xBE
-                if (xml == null && resultComponent != AssociationResult.ACCEPTED
-                        && resultDiagnosticValue != SourceDiagnostic.NONE) {
-                    throw new GXDLMSException(resultComponent,
-                            resultDiagnosticValue);
-                }
                 parseUserInformation(settings, cipher, buff, xml);
                 break;
             default:
@@ -948,6 +943,11 @@ final class GXAPDU {
                 }
                 break;
             }
+        }
+        if (xml == null && resultComponent != AssociationResult.ACCEPTED
+                && resultDiagnosticValue != SourceDiagnostic.NONE) {
+            throw new GXDLMSException(resultComponent,
+                    resultDiagnosticValue);
         }
         return resultDiagnosticValue;
     }


### PR DESCRIPTION
AARE association rejected check was done only when User-information field was also received in the AARE. This is wrong since some meters will send AARE without user-information when rejected. 