### PR TITLE
Fix missing enum values

### DIFF
--- a/development/src/main/java/gurux/dlms/objects/GXDLMSSecuritySetup.java
+++ b/development/src/main/java/gurux/dlms/objects/GXDLMSSecuritySetup.java
@@ -1771,9 +1771,8 @@ public class GXDLMSSecuritySetup extends GXDLMSObject implements IGXDLMSBase {
 
     @Override
     public String[] getNames() {
-        return new String[] { "Logical Name", "Security Policy",
-                "Security Suite", "Client System Title",
-                "Server System Title" };
+        return new String[] { "Logical Name", "Security Policy", "Security Suite",
+                "Client System Title", "Server System Title", "Certificates" };
     }
 
     @Override

--- a/development/src/main/java/gurux/dlms/objects/enums/GsmPacketSwitchStatus.java
+++ b/development/src/main/java/gurux/dlms/objects/enums/GsmPacketSwitchStatus.java
@@ -38,32 +38,14 @@ package gurux.dlms.objects.enums;
  * Packet switched status of the modem.
  */
 public enum GsmPacketSwitchStatus {
-    /**
-     * Inactive
-     */
     INACTIVE,
-    /**
-     * GPRS
-     */
     GPRS,
-    /**
-     * EDGE
-     */
     EDGE,
-    /**
-     * UMTS
-     */
     UMTS,
-    /**
-     * HSDPA
-     */
     HSDPA,
-    /**
-     * LTE
-     */
     LTE,
-    /**
-     * CDMA
-     */
-    CDMA
+    CDMA,
+    LTE_CAT_M1,
+    LTE_CAT_NB1,
+    LTE_CAT_NB2
 }


### PR DESCRIPTION
Hi Mikko,
I just found that SecuritySetup does not contain description for Certificates.

I also added missing enum values for GSMPacketSwitchStatus, which I was also suggesting in last PullRequest, but I think you missed that: https://github.com/Gurux/gurux.dlms.java/pull/36#issuecomment-2595250889 and https://github.com/Gurux/gurux.dlms.java/pull/36#issuecomment-2592768806

With suggestion about commenting enum values: I think, that in this case, the use of comment is redundant. It is much more readable, when I can see all the enums without the use of comments, that say the same thing as the enum name itself.