### PR TITLE
Fix bulk removal method in GXArray

### DIFF
--- a/development/src/main/java/gurux/dlms/GXArray.java
+++ b/development/src/main/java/gurux/dlms/GXArray.java
@@ -44,11 +44,9 @@ public class GXArray extends ArrayList<Object> implements java.util.List<Object>
 
     /**
      * Remove all elements within the specified range.
+     * Both arguments {@code fromIndex} and {@code toIndex} are inclusive.
      */
     public void removeRange(int fromIndex, int toIndex) {
-        while (fromIndex <= toIndex) {
-            this.remove(fromIndex);
-            ++fromIndex;
-        }
+        subList(fromIndex, toIndex + 1).clear();
     }
 }


### PR DESCRIPTION
The original code removed individual list items in ascending index order. However, it deleted only every second element, because it incremented index and shifted elements at the same time. Probability of throwing an exception is high when operating near the end of the list. The code was replaced by the idiomatic approach suggested by JDK Javadoc of `List.sublist()` method.

The interpretation of the boundary indices' behavior - original code implies that both are inclusive - was documented. This interpretation, however, appears incorrect in context of calls from `GXDLMSArrayManager`, and **needs to be double-checked during code review**.